### PR TITLE
Fixing a case-sensitivity-typo in your inclusion of BitBoard.fs that …

### DIFF
--- a/FsChessPgn/FsChessPgn.fsproj
+++ b/FsChessPgn/FsChessPgn.fsproj
@@ -101,7 +101,7 @@
     <Compile Include="DateUtil.fs" />
     <Compile Include="NagUtil.fs" />
     <Compile Include="Stats.fs" />
-    <Compile Include="Bitboard.fs" />
+    <Compile Include="BitBoard.fs" />
     <Compile Include="Attacks.fs" />
     <Compile Include="FEN.fs" />
     <Compile Include="Move.fs" />


### PR DESCRIPTION
…prevents project from building on non-windows platforms