### PR TITLE
fix for two tests failing on non-windows

### DIFF
--- a/FsChessPgn.Test/RealFileTests.fs
+++ b/FsChessPgn.Test/RealFileTests.fs
@@ -22,13 +22,13 @@ type RealFileTests () =
 
     [<TestMethod>]
     member this.Lon09R5() =
-        let db = Games.ReadFromFile(TestSet+"Lon09R5.pgn")
+        let db = Games.ReadFromFile(TestSet+"lon09r5.pgn")
 
         Assert.AreEqual(db|>Seq.length,4)
 
     [<TestMethod>]
     member this.Tilb98R2() =
-        let db = Games.ReadFromFile(TestSet+"Tilb98R2.pgn")
+        let db = Games.ReadFromFile(TestSet+"tilb98r2.pgn")
 
         Assert.AreEqual(db|>Seq.length,6)
 


### PR DESCRIPTION
this doesn't affect compilation but since the case of the filename doesn't match the case of the file on disk, these two tests were failing. now all 127 tests pass as intended regardless of windows or not (tested on ubuntu)